### PR TITLE
Use protonvpn through openvpn

### DIFF
--- a/.i3/i3status-rs.toml
+++ b/.i3/i3status-rs.toml
@@ -99,7 +99,7 @@ interval = 60
 
 [[block]]
 block = "net"
-device = "proton0"
+device = "tun0"
 hide_missing = true
 hide_inactive = true
 interval = 5


### PR DESCRIPTION
The newer version of the protonvpn-cli tool depends on NetworkManager,
which is not available on my systems. To circumvent this, openvpn is now used instead.